### PR TITLE
Add name tag to layout block

### DIFF
--- a/view/frontend/layout/dibsflexwin_index_request.xml
+++ b/view/frontend/layout/dibsflexwin_index_request.xml
@@ -9,7 +9,7 @@
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-           <block class="Dibs\Flexwin\Block\Redirect" template="Dibs_Flexwin::form.phtml" cacheable="false"/>
+           <block class="Dibs\Flexwin\Block\Redirect" name="flexwin_dibs_form_redirect" template="Dibs_Flexwin::form.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>


### PR DESCRIPTION
Magento 2.3.5-p1 will default cache a block without name. 
This leads to cached params on the redirect page, which gives an error when it redirects to DIBS.
@maxwhite 