### PR TITLE
Fix typo in config.xml causing enlarged images in checkout

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -17,7 +17,7 @@
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <form_action_url>https://payment.architrade.com/paymentweb/start.action</form_action_url>
                 <place_order_url>dibsflexwin/index/request</place_order_url>
-                <logo_with>125</logo_with>
+                <logo_width>125</logo_width>
             </dibs_flexwin>
         </payment>
     </default>


### PR DESCRIPTION

A typo in the config.xml is causing the images for the payment methods to not be resized
This Pull request fixes that typo.

Before
![Selection_058](https://user-images.githubusercontent.com/9111275/86255013-ea71f400-bbb6-11ea-94cf-478c7b60d441.png)
After
![Selection_059](https://user-images.githubusercontent.com/9111275/86255041-f362c580-bbb6-11ea-8b3e-3bdd2cddd649.png)

