### PR TITLE
Add accept callback controller to skip CSRF validation

### DIFF
--- a/Plugin/CsrfValidatorSkip.php
+++ b/Plugin/CsrfValidatorSkip.php
@@ -14,7 +14,7 @@ class CsrfValidatorSkip {
         \Magento\Framework\App\RequestInterface $request,
         \Magento\Framework\App\ActionInterface $action
     ) {
-        if ('dibsflexwin' == $request->getModuleName() && in_array($request->getActionName(), ['callback', 'cancel'])) {
+        if ('dibsflexwin' == $request->getModuleName() && in_array($request->getActionName(), ['callback', 'cancel', 'accept'])) {
             return;
         }
         $proceed($request, $action);


### PR DESCRIPTION

Current version of the module causes a form key error due to the post controller that handles the accept callback is not excluded from CSRF validation.

This fixes that problem